### PR TITLE
Feat: 매칭 내역(게스팅 내역) 페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -19,6 +19,7 @@ import TeamSelectionPage from './pages/team/TeamSelectionPage';
 import TeamCreatePage from './pages/team/TeamCreatePage';
 import LocationList from './pages/location/LocationList';
 import LocationWrite from './pages/location/LocationWrite';
+import ReviewsPage from './pages/ReviewsPage/ReviewsPage';
 
 function App() {
   return (
@@ -53,6 +54,7 @@ function ContentBox() {
         <Route path='/matching/weeklycalendar' element={<WeeklyCalendar />} />
         <Route path='/location' element={<LocationList />} />
         <Route path='/location/write' element={<LocationWrite />} />
+        <Route path='/reviews' element={<ReviewsPage />} />
       </Routes>
       <Footer />
     </div>

--- a/src/pages/ReviewsPage/ReviewsPage.jsx
+++ b/src/pages/ReviewsPage/ReviewsPage.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import * as S from './ReviewsPage.style';
+import WeeklyCalendar from '../../components/layouts/WeeklyCalendar';
+import MatchList from '../../components/layouts/Matching/MatchList';
+
+const NAV_ITEM_LIST = [
+  {
+    label: '게스팅 내역',
+    url: '#',
+  },
+  {
+    label: '호스팅 내역',
+    url: '#',
+  },
+];
+
+export default function ReviewsPage() {
+  return (
+    <S.PageLayout>
+      <S.Nav>
+        {NAV_ITEM_LIST.map(({ label, url }) => (
+          <S.NavItem key={label} href={url}>
+            {label}
+          </S.NavItem>
+        ))}
+      </S.Nav>
+      <S.Banner></S.Banner>
+      <WeeklyCalendar />
+      <MatchList />
+    </S.PageLayout>
+  );
+}

--- a/src/pages/ReviewsPage/ReviewsPage.style.jsx
+++ b/src/pages/ReviewsPage/ReviewsPage.style.jsx
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+export const PageLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const Nav = styled.nav`
+  display: flex;
+  flex-direction: row;
+  gap: 30px;
+  align-items: center;
+  padding: 11px 20px;
+`;
+
+export const NavItem = styled.a`
+  padding: 5px;
+  color: var(--Blue300, #0075ff);
+  text-align: center;
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 18px;
+`;
+
+export const Banner = styled.div`
+  background: var(--Blue400, #2e69ff);
+  height: 160px;
+`;

--- a/src/pages/ReviewsPage/index.js
+++ b/src/pages/ReviewsPage/index.js
@@ -1,0 +1,1 @@
+export { default } from './ReviewsPage';


### PR DESCRIPTION
## #️⃣관련 이슈

#28

## 📝작업 내용

매칭 내역(게스팅 내역) 페이지 구현하였습니다.

[참고 내용]
- 게스팅 내역, 호스팅 내역(NavItem)에 밑줄 들어간 부분은, reset.css 파일이 dev 브랜치에 반영되면 자동으로 사라질 예정입니다.
- 호스팅 내역 글자색은 추후에 gray로 수정하겠습니다.

<img src="https://github.com/TiimMate/TeamMateClient/assets/128569095/a4f631ae-7e24-4705-9612-e22894329a03" width="280px" /> 